### PR TITLE
Device widget

### DIFF
--- a/src/frontend/components/DeviceWidget.tsx
+++ b/src/frontend/components/DeviceWidget.tsx
@@ -8,7 +8,7 @@ interface Props {
     isConnected: boolean;
 }
 
-const width = Dimensions.get('window').width;
+const windowWidth = Dimensions.get('window').width;
 
 export const DeviceWidget = ({ name, isConnected }: Props) => {
     const statusIcon = isConnected ? (
@@ -25,7 +25,10 @@ export const DeviceWidget = ({ name, isConnected }: Props) => {
                     style={{
                         ...styles.deviceName,
                         ...{
-                            color: isConnected ? Colours.BLACK : Colours.GREY
+                            color: isConnected ? Colours.BLACK : Colours.GREY,
+                            fontFamily: isConnected
+                                ? 'DMSans-Bold'
+                                : 'DMSans-Regular'
                         }
                     }}
                 >
@@ -64,7 +67,7 @@ export const DeviceWidget = ({ name, isConnected }: Props) => {
 const styles = StyleSheet.create({
     container: {
         height: 60,
-        width: width * 0.88,
+        width: windowWidth * 0.88,
         alignItems: 'center',
         justifyContent: 'space-between',
         flexDirection: 'row',
@@ -84,8 +87,7 @@ const styles = StyleSheet.create({
     },
     deviceName: {
         marginLeft: 10,
-        fontSize: 16,
-        fontWeight: 'DMSans-Bold'
+        fontSize: 16
     },
     statusBar: {
         width: '100%',


### PR DESCRIPTION
| On state  | Off state  |
|---|---|
| <img width="315" alt="Screen Shot 2022-11-20 at 4 11 32 PM" src="https://user-images.githubusercontent.com/41706038/202934257-3502571b-971e-4e81-b5b1-75f633824ff8.png"> | <img width="316" alt="Screen Shot 2022-11-20 at 4 11 56 PM" src="https://user-images.githubusercontent.com/41706038/202934274-2fcbb23b-fe76-4345-b98a-681a94cc4dbe.png"> |
